### PR TITLE
Fix accessibility issue in partials for page header

### DIFF
--- a/src/_includes/partials/header.njk
+++ b/src/_includes/partials/header.njk
@@ -2,7 +2,7 @@
 <header>
     <h2>{{ header[locale].heading }}</h2>
 
-    <section  lang="{{ otherLang }}">
+    <div  lang="{{ otherLang }}">
         {# loop though site.languages #}
         {% for lgg in site.languages %}
         {% if loop.first %}<ul>{% endif %}
@@ -33,5 +33,5 @@
 
         {% if loop.last %}</ul>{% endif %}
         {% endfor %}
-    </section>
+    </div>
 </header>

--- a/src/_includes/partials/nav.njk
+++ b/src/_includes/partials/nav.njk
@@ -1,7 +1,6 @@
-<section>
-{{ nav[locale].title }}
-
 <nav>
+
+    <h2>{{ nav[locale].title }}</h2>
 
     {% set navPages = collections.all | eleventyNavigation %}
 
@@ -33,4 +32,3 @@
     {%- endfor -%}
     </ul>
 </nav>
-</section>


### PR DESCRIPTION
# Summary | Résumé

Fixing accessibility issue I found with a quick manual assessment. Those error was not found by the accessibility automated testing recently implemented.

The `<section>` element is useless because a `<nav>` is also a section. And where the name of the section should be instead moved as a heading for the navigation element.

Also, some section lacks heading, see the three (3) HTML validation warning: https://validator.nu/?doc=https%3A%2F%2Fcds-snc.github.io%2Falpha-design-system-documentation%2Fen%2F

---
related: https://github.com/cds-snc/design-gc-conception/issues/103