### PR TITLE
Change heading anchor format

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -3,8 +3,9 @@ const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
 const sitemap = require("@quasibit/eleventy-plugin-sitemap");
 const moment = require("moment");
 const markdownIt = require("markdown-it");
-const markdownItAnchor = require("markdown-it-anchor");
+const slugify = require("./utils/slugify");
 const contextMenu = require("./utils/context-menu");
+const markdownAnchor = require("./utils/anchor");
 const svgContents = require("eleventy-plugin-svg-contents");
 
 module.exports = function (eleventyConfig) {
@@ -34,7 +35,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addFilter("onThisPage", function(nodes) {
     let urls = {};
     for (let key in nodes) {
-      urls[nodes[key]] = nodes[key].toLowerCase().replaceAll(' ', '-');
+      urls[nodes[key]] = slugify(nodes[key]);
     }
     return urls;
   });
@@ -51,11 +52,7 @@ module.exports = function (eleventyConfig) {
     html: true,
     breaks: false,
     linkify: true
-  }).use(markdownItAnchor, {
-    permalink: true,
-    permalinkClass: "direct-link",
-    permalinkSymbol: "#"
-  });
+  }).use(markdownAnchor);
   markdownLibrary.disable('blockquote');
   markdownLibrary.disable('code');
   eleventyConfig.setLibrary("md", markdownLibrary);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@11ty/eleventy-navigation": "^0.3.2",
     "gcds-components": "^0.0.4",
     "markdown-it": "^12.2.0",
-    "markdown-it-anchor": "^8.4.1",
     "moment": "^2.29.1"
   },
   "devDependencies": {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -23,6 +23,23 @@ body {
 }
 
 /*
+ * Heading anchors
+ */
+
+h2 > a.anchor-link,
+h3 > a.anchor-link {
+  color: #000;
+  text-decoration: none;
+}
+
+h2 > a.anchor-link:hover,
+h2 > a.anchor-link:focus,
+h3 > a.anchor-link:hover,
+h3 > a.anchor-link:focus {
+  text-decoration: underline;
+}
+
+/*
  * Breadcrumbs
  */
 

--- a/utils/anchor.js
+++ b/utils/anchor.js
@@ -1,0 +1,32 @@
+const slugify = require("./slugify");
+
+const defaultOptions = {
+  anchorClass: 'anchor-link',
+};
+
+const anchor = (md, options) => {
+  options = Object.assign({}, defaultOptions, options);
+
+  md.renderer.rules.heading_open = function(tokens, index) {
+    const contentToken = tokens[index + 1];
+    const slug = slugify(contentToken.content);
+
+    if (tokens[index].tag === 'h2' || tokens[index].tag === 'h3') {
+      return `
+        <${tokens[index].tag} id="${slug}">
+            <a class="${options.anchorClass}" href="#${slug}">`;
+    }
+    return `<${tokens[index].tag}>`;
+  };
+
+  md.renderer.rules.heading_close = function(tokens, index) {
+    if (tokens[index].tag === 'h2' || tokens[index].tag === 'h3') {
+      return `
+            </a>
+        </${tokens[index].tag}>`;
+    }
+    return `</${tokens[index].tag}>`;
+  };
+};
+
+module.exports = anchor;

--- a/utils/slugify.js
+++ b/utils/slugify.js
@@ -1,0 +1,22 @@
+const slugify = (s) =>
+  encodeURIComponent(
+    String(s)
+      .trim()
+      .toLowerCase()
+      .replace(/[ÀÁÂÃÄÅ]/g,"A")
+      .replace(/[àáâãäå]/g,"a")
+      .replace(/[ÈÉÊË]/g,"E")
+      .replace(/[èéêë]/g,"e")
+      .replace(/[ÍÌÎÏ]/g,"I")
+      .replace(/[íìîï]/g,"i")
+      .replace(/[ÓÒÔÕÖ]/g,"O")
+      .replace(/[óòôõö]/g,"o")
+      .replace(/[ÚÙÛÜ]/g,"U")
+      .replace(/[úùûü]/g,"u")
+      .replace(/[Ç]/g,"C")
+      .replace(/[ç]/g,"c")
+      .replace(/[^\w\s]|_/g, "")
+      .replace(/\s+/g, '-')
+  );
+
+  module.exports = slugify;


### PR DESCRIPTION
# Summary 

Change formatting of heading anchors to be more usable. Now only formats `h2` and `h3` headings.

**Previous format**
``` html
<h2 id="use-the-basic-button-component" tabindex="-1">
   Use the basic button component 
   <a class="direct-link" href="#use-the-basic-button-component">#</a>
</h2>
```
**New format** 
``` html
<h2 id="use-the-basic-button-component">
   <a class="anchor-link" href="#use-the-basic-button-component">
      Use the basic button component
   </a>
</h2>
```
