### PR TITLE
Add viewCode shortcode

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -11,6 +11,7 @@ const svgContents = require("eleventy-plugin-svg-contents");
 module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy("./src/styles/style.css");
   eleventyConfig.addPassthroughCopy("./src/styles/prism.css");
+  eleventyConfig.addPassthroughCopy("./src/scripts/code-showcase.js");
   eleventyConfig.addPassthroughCopy("./src/admin/config.yml");
   eleventyConfig.addPlugin(svgContents);
   eleventyConfig.addPassthroughCopy({"./src/variables/": "variables"});
@@ -55,6 +56,34 @@ module.exports = function (eleventyConfig) {
   }).use(markdownAnchor);
   markdownLibrary.disable('blockquote');
   markdownLibrary.disable('code');
+
+  eleventyConfig.addPairedShortcode('viewCode', (children, lang, id) => {
+    const langStrings = {
+      "en": {
+        "view": "View code",
+        "copy": "Copy code"
+      },
+      "fr": {
+        "view": "Voir le code",
+        "copy": "Copier le code"
+      }
+    }
+    let copyCode = children;
+    copyCode = copyCode.toString().replace("``` html", "").replace("```", "").replaceAll("<", "&lt;").replaceAll(">", "&gt;").trim();
+    const content = markdownLibrary.render(children);
+
+    return `
+    <div class="code-showcase">
+    <gcds-button button-type="button" button-role="secondary" button-style="text-only" onclick="toggleCodeShowcase(this, '${id}');" aria-controls="${id}" aria-expanded="false">${langStrings[lang].view}</gcds-button>
+    <gcds-button button-type="button" button-role="secondary" button-style="text-only" onclick="copyCodeShowcase(this, '${id}', '${lang}');" onblur="this.innerText = '${langStrings[lang].copy}'">${langStrings[lang].copy}</gcds-button>
+    <div class="showcase" id="${id}" aria-hidden="true">
+      ${content}
+    <code class="copy-code" id="${id}-copy">${copyCode}</code>
+    </div>
+    </div>
+    `}
+  );
+
   eleventyConfig.setLibrary("md", markdownLibrary);
 
   eleventyConfig.addPlugin(sitemap, {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -77,12 +77,12 @@ module.exports = function (eleventyConfig) {
 
     return `
     <div class="code-showcase">
-    <gcds-button button-type="button" button-role="secondary" button-style="text-only" onclick="toggleCodeShowcase(this, '${id}');" aria-controls="${id}" aria-expanded="false">${langStrings[lang].view}</gcds-button>
-    <gcds-button button-type="button" button-role="secondary" button-style="text-only" onclick="copyCodeShowcase(this, '${id}', '${lang}');" onblur="this.innerText = '${langStrings[lang].copy}'">${langStrings[lang].copy}</gcds-button>
-    <div class="showcase" id="${id}" aria-hidden="true">
-      ${content}
-    <code class="copy-code" id="${id}-copy">${copyCode}</code>
-    </div>
+      <gcds-button button-type="button" button-role="secondary" button-style="text-only" onclick="toggleCodeShowcase(this, '${id}');" aria-controls="${id}" aria-expanded="false">${langStrings[lang].view}</gcds-button>
+      <gcds-button button-type="button" button-role="secondary" button-style="text-only" onclick="copyCodeShowcase(this, '${id}', '${lang}');" onblur="this.innerText = '${langStrings[lang].copy}'">${langStrings[lang].copy}</gcds-button>
+      <div class="showcase" id="${id}" aria-hidden="true">
+        ${content}
+        <code class="copy-code" id="${id}-copy">${copyCode}</code>
+      </div>
     </div>
     `}
   );

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -68,6 +68,9 @@ module.exports = function (eleventyConfig) {
         "copy": "Copier le code"
       }
     }
+    if (lang != "en " && lang != "fr") {
+      lang = "en";
+    }
     let copyCode = children;
     copyCode = copyCode.toString().replace("``` html", "").replace("```", "").replaceAll("<", "&lt;").replaceAll(">", "&gt;").trim();
     const content = markdownLibrary.render(children);

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -12,6 +12,7 @@
         <link rel="stylesheet" href="{{ '/components/dist/gcds/gcds.css' | url }}">
         <link rel="stylesheet" href="{{ '/styles/prism.css' | url }}">
         <link rel="stylesheet" href="{{ '/styles/style.css' | url }}">
+        <script src="/scripts/code-showcase.js" />
 
     </head>
     <body>

--- a/src/scripts/code-showcase.js
+++ b/src/scripts/code-showcase.js
@@ -1,0 +1,21 @@
+function toggleCodeShowcase(trigger, id) {
+    const element = document.querySelector(`#${id}`);
+    if (element.getAttribute("aria-hidden") == "true") {
+        element.setAttribute("aria-hidden", false);
+        trigger.setAttribute("aria-expanded", "true");
+    } else {
+        element.setAttribute("aria-hidden", true);
+        trigger.setAttribute("aria-expanded", "false");
+    }
+}
+
+function copyCodeShowcase(trigger, id, lang) {
+    const element = document.querySelector(`#${id}-copy`);
+
+    navigator.clipboard.writeText(element.innerText);
+    if (lang == "en") {
+        trigger.innerText = "Copied";
+    } else {
+        trigger.innerText = "Copié";
+    }
+}

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -179,3 +179,18 @@ aside {
   text-decoration: none;
   border-bottom: 1px solid #000;
 }
+
+
+/*
+ * Code showcase
+ */
+
+.code-showcase > div.showcase[aria-hidden=true] {
+  display: none;
+  visibility: hidden;
+}
+
+.code-showcase code.copy-code {
+  display: none;
+  visibility: hidden;
+}


### PR DESCRIPTION
# Summary

Created new shortcode for hiding/displaying code blocks and providing people with the option to copy the displayed code.

## Use

In the documentation markdown file, add the following markup to your document.

``` md
{% viewCode "lang", "id" %}

< code block code>

{% endviewCode %}
```

### Arguments

**lang**: Current language of page - en or fr
**id**: Unique id to represent this code block - string
