### PR TITLE
feat: add experimental banner above header

### DIFF
--- a/src/_data/experimentalbanner.js
+++ b/src/_data/experimentalbanner.js
@@ -1,0 +1,8 @@
+module.exports = {
+    en : {
+        bannerText: "This tool is currently being piloted on a small scale. Contact us if you'd like to pilot this tool in your service.",
+    },
+    fr: {
+        bannerText: "Cet outil fait actuellement l'objet d'un petit projet pilote. Contactez-nous si vous souhaitez essayer l'outil dans votre service.",
+    }
+}

--- a/src/_includes/partials/experimentalbanner.njk
+++ b/src/_includes/partials/experimentalbanner.njk
@@ -1,0 +1,5 @@
+<div class="banner">
+    <p class="container">
+        <span class="banner__icon">Alpha</span> {{ experimentalbanner[locale].bannerText }}
+    </p>
+</div>

--- a/src/_includes/partials/header.njk
+++ b/src/_includes/partials/header.njk
@@ -1,4 +1,7 @@
 {% set otherLang = "fr" if locale == "en" else "en" %}
+
+{% include "partials/experimentalbanner.njk" %}
+
 <header class="header">
     <div class="header__container">
         <a class="header__logo" href="https://www.canada.ca/" target="_blank" aria-label="{% if locale == "en" %}Canada.ca site (Opens in a new tab){% else %}Site Web Canada.ca (S'ouvre dans un nouvel onglet){% endif %}">

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -94,6 +94,38 @@ h3 > a.anchor-link:focus {
 }
 
 /*
+ * Banner
+ */
+.banner {
+  font-size: 14px;
+  padding: 8px;
+  background-color: #26374A;
+  color: #FFF;
+}
+
+.banner p {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@media only screen and (max-width: 530px) {
+  .banner p {
+    align-items: flex-start;
+  }
+}
+
+.banner .banner__icon {
+  display: inline-block;
+  font-weight: 700;
+  text-align: center;
+  margin: 0 10px 0 0;
+  padding: 4px 8px;
+  background-color: #FFF;
+  color: #000;
+}
+
+/*
  * Breadcrumbs
  */
 


### PR DESCRIPTION
# Summary | Résumé

Add an experimental banner above the header to inform users that this tool is still currently being worked on.