### PR TITLE
fix: missing message field on the notify personalisation

### DIFF
--- a/api/src/index.js
+++ b/api/src/index.js
@@ -119,9 +119,9 @@ app.post('/submission', async (req, res) => {
     personalisation: {
       name: name,
       email: email,
-      message: message,
-      learnMore: learnMore,
-      familiarityGCDS: familiarityGCDS,
+      message: message ? message : '',
+      learnMore: learnMore ? learnMore : '',
+      familiarityGCDS: familiarityGCDS ? familiarityGCDS : '',
     },
   });
 


### PR DESCRIPTION
# Summary | Résumé

Fix for issue where the message field doesn't get sent if it's blank