### PR TITLE
fix: Add novalidate to contact us form

### DIFF
--- a/src/en/contact/contact.md
+++ b/src/en/contact/contact.md
@@ -37,13 +37,15 @@ We’ll soon be offering other events to our growing community.
 
 This form is for people building government websites and digital products. You can give feedback, ask a question, or receive communications from the GC Design System team. If you need help with a government service, go to <gcds-link href="https://www.canada.ca/en/contact.html" external>Government of Canada contacts</gcds-link>.
 
-<form class="my-600 contact-us-form" name="contactEN" method="post" style="min-height: 32rem;" action="/api/submission">
+<form class="my-600 contact-us-form" name="contactEN" method="post" style="min-height: 32rem;" action="/api/submission" novalidate>
+  <gcds-error-summary></gcds-error-summary>
+
   <input type="hidden" name="form-name" value="contactEN" />
   <input name="honeypot" type="text" aria-label="bot" hidden/>
 
-<gcds-input type="text" name="name" input-id="name" label="Full name" autocomplete="name" required></gcds-input>
-<gcds-input type="email" name="email" input-id="email" label="Email address" autocomplete="email" required></gcds-input>
-<gcds-textarea name="message" label="Provide your feedback or ask a question if you need help" hint="Never include personal (Protected) information." textarea-id="message"></gcds-textarea>
+  <gcds-input type="text" name="name" input-id="name" label="Full name" autocomplete="name" required></gcds-input>
+  <gcds-input type="email" name="email" input-id="email" label="Email address" autocomplete="email" required></gcds-input>
+  <gcds-textarea name="message" label="Provide your feedback or ask a question if you need help" hint="Never include personal (Protected) information." textarea-id="message"></gcds-textarea>
 
   <gcds-fieldset legend="Receive communication from GC Design System" legend-size="h3" hint="If you'd like us to contact you, choose one or both options.">
     <gcds-checkboxes name="learn-more-mailing-list" options="{{ contactus[locale].mailingcheck | stringify | encode-html }}"></gcds-checkboxes>

--- a/src/fr/contactez/contactez.md
+++ b/src/fr/contactez/contactez.md
@@ -38,13 +38,15 @@ Ce formulaire est destiné aux personnes qui bâtissent les sites Web et service
 
 Pour obtenir de l’aide avec un service gouvernemental, aller à la page <gcds-link href="https://www.canada.ca/fr/contact.html" external>Coordonnées du Gouvernement du Canada</gcds-link>.
 
-<form class="my-600 contact-us-form" name="contactFR" method="post" style="min-height: 32rem;" action="/api/submission">
+<form class="my-600 contact-us-form" name="contactFR" method="post" style="min-height: 32rem;" action="/api/submission" novalidate>
+  <gcds-error-summary></gcds-error-summary>
+
   <input type="hidden" name="form-name" value="contactFR" />
   <input name="honeypot" type="text" aria-label="bot" hidden/>
 
-<gcds-input type="text" name="name" input-id="name" label="Nom complet" autocomplete="name" required></gcds-input>
-<gcds-input type="email" name="email" input-id="email" label="Adresse courriel" autocomplete="email" required></gcds-input>
-<gcds-textarea name="message" label="Fournissez vos commentaires ou posez une question si vous avez besoin d’aide" hint="Incluez jamais de renseignement personnel (Protégé)." textarea-id="message"></gcds-textarea>
+  <gcds-input type="text" name="name" input-id="name" label="Nom complet" autocomplete="name" required></gcds-input>
+  <gcds-input type="email" name="email" input-id="email" label="Adresse courriel" autocomplete="email" required></gcds-input>
+  <gcds-textarea name="message" label="Fournissez vos commentaires ou posez une question si vous avez besoin d’aide" hint="Incluez jamais de renseignement personnel (Protégé)." textarea-id="message"></gcds-textarea>
 
   <gcds-fieldset legend="Recevez des communications de la part de Système de design GC" legend-size="h3" hint="Si vous souhaitez que nous vous contactions, choisissez une option ou les deux options.">
     <gcds-checkboxes name="learn-more-mailing-list" options="{{ contactus[locale].mailingcheck | stringify | encode-html }}"></gcds-checkboxes>


### PR DESCRIPTION
# Summary | Résumé

Add `novalidate` attribute to the contact us forms to disable browser validation in favour of the built in validation of the GC Design System. Also added a `gcds-error-summary` to each form to bring attention to any validation errors that may be present in the form since they exist at the top of the form.
