### PR TITLE
feat: Update renovate config to pull GCDS packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
       "matchPackageNames": [
         "@cdssnc/gcds-components",
         "@cdssnc/gcds-tokens",
-        "@gcds-core/css-shortcuts"
+        "@gcds-core/*"
       ],
       "groupName": "GCDS packages",
       "prPriority": 1,


### PR DESCRIPTION
# Summary | Résumé

Add custom configuration to renovate to create immediate PRs for GCDS packages using the [packageRules](https://docs.renovatebot.com/configuration-options/#packagerules) configuration.
