### PR TITLE
fix: Make select your experience required

### DIFF
--- a/src/en/contact/contact.md
+++ b/src/en/contact/contact.md
@@ -52,7 +52,7 @@ This form is for people building government websites and digital products. You c
     <gcds-checkboxes name="learn-more-research" options="{{ contactus[locale].researchcheck | stringify | encode-html }}"></gcds-checkboxes>
   </gcds-fieldset>
 
-  <gcds-radios legend="Select your experience with GC Design System to date" hint="Choose 1 option." name="familiarityGCDS" options='{{ contactus[locale].radiooptions | stringify | encode-html}}'>
+  <gcds-radios legend="Select your experience with GC Design System to date" hint="Choose 1 option." name="familiarityGCDS" required options='{{ contactus[locale].radiooptions | stringify | encode-html}}'>
   </gcds-radios>
 
   <div hidden>

--- a/src/fr/contactez/contactez.md
+++ b/src/fr/contactez/contactez.md
@@ -53,7 +53,7 @@ Pour obtenir de l’aide avec un service gouvernemental, aller à la page <gcds-
     <gcds-checkboxes name="learn-more-research" options="{{ contactus[locale].researchcheck | stringify | encode-html }}"></gcds-checkboxes>
   </gcds-fieldset>
 
-  <gcds-radios legend="Indiquez votre expérience avec Système de design GC" hint="Sélectionnez 1 option." name="familiarityGCDS" options='{{ contactus[locale].radiooptions | stringify | encode-html}}'>
+  <gcds-radios legend="Indiquez votre expérience avec Système de design GC" hint="Sélectionnez 1 option." name="familiarityGCDS" required options='{{ contactus[locale].radiooptions | stringify | encode-html}}'>
   </gcds-radios>
 
   <div hidden>


### PR DESCRIPTION
# Summary | Résumé

Make the "Select your experience with GC Design System to date" `gcds-radios` on the contact form required to match the backend logic. 

https://github.com/cds-snc/gcds-docs/issues/668
