### PR TITLE
fix: remove responsive styles section from css shortcuts font size pages

### DIFF
--- a/src/en/css-shortcuts/font-size.md
+++ b/src/en/css-shortcuts/font-size.md
@@ -152,5 +152,3 @@ The font size class sets the `font-size` property. It controls how big or small 
   This element uses the font size intended for small text.
 </p>
 {% endshortcutPreview %}
-
-{% include "partials/responsive-layout.njk" %}

--- a/src/fr/raccourcis-css/taille-de-police.md
+++ b/src/fr/raccourcis-css/taille-de-police.md
@@ -152,5 +152,3 @@ La classe taille de police définit la propriété `font-size`. Elle détermine 
   Cet élément utilise la taille de police prévue pour du petit texte.
 </p>
 {% endshortcutPreview %}
-
-{% include "partials/responsive-layout.njk" %}


### PR DESCRIPTION
# Summary | Résumé

To avoid any confusion for our users, I'm removing the responsive styles section from our CSS Shortcuts font size pages since the responsive prefix is not applicable for font sizes.

## Preview

- [EN preview](https://pr-685.djtlis5vpn8jd.amplifyapp.com/en/css-shortcuts/font-size/)
- [FR preview](https://pr-685.d35vdwuoev573o.amplifyapp.com/fr/raccourcis-css/taille-de-police/)