### PR TITLE
fix: missing language toggle from design start to use pages

### DIFF
--- a/src/en/start-to-use/design.md
+++ b/src/en/start-to-use/design.md
@@ -1,9 +1,9 @@
 ---
 title: Set up GC Design System library
-translationKey: startusingFigma
+translationKey: startUsingFigma
 layout: 'layouts/base.njk'
 eleventyNavigation:
-  key: startusingFigmaEN
+  key: startUsingFigmaEN
   title: Set up GC Design System library
   locale: en
   parent: startusingEN


### PR DESCRIPTION
# Summary | Résumé

The EN and FR pages for the design start-to-use page weren't using the same translationKey which was preventing the language toggle from being displayed.