### PR TITLE
fix: CDN version number

### DIFF
--- a/src/_includes/layouts/installation-html.njk
+++ b/src/_includes/layouts/installation-html.njk
@@ -48,5 +48,7 @@ layout: "layouts/base.njk"
     }
   }
 
-  getLatestCdnVersion();
+  setTimeout(() => {
+    getLatestCdnVersion();
+  }, 100);
 </script>


### PR DESCRIPTION
# Summary | Résumé

As mentioned in https://github.com/cds-snc/gcds-docs/issues/734, the version number in the CDN install instructions would not be replaced and would appear as `||version||`. Add a small timeout to the replacement function to allow other scripts to finish before text replacement.

- [French link](https://pr-737.d35vdwuoev573o.amplifyapp.com/fr/demarrer/developpement/html/#installation-avec-cdn)
- [English link](https://pr-737.djtlis5vpn8jd.amplifyapp.com/en/start-to-use/develop/html/#cdn-installation-instructions)
