### PR TITLE
feat: Update to new package scope in installation instructions

### DIFF
--- a/src/en/en.json
+++ b/src/en/en.json
@@ -192,10 +192,10 @@
     "githubTokens": "https://github.com/cds-snc/gcds-tokens",
     "githubTokensIssues": "https://github.com/cds-snc/gcds-tokens/issues",
 
-    "npmGcdsComponents": "https://www.npmjs.com/package/@cdssnc/gcds-components",
-    "npmGcdsComponentsAngular": "https://www.npmjs.com/package/@cdssnc/gcds-components-angular",
-    "npmGcdsComponentsReact": "https://www.npmjs.com/package/@cdssnc/gcds-components-react",
-    "npmGcdsComponentsVue": "https://www.npmjs.com/package/@cdssnc/gcds-components-vue",
+    "npmGcdsComponents": "https://www.npmjs.com/package/@gcds-core/components",
+    "npmGcdsComponentsAngular": "https://www.npmjs.com/package/@gcds-core/components-angular",
+    "npmGcdsComponentsReact": "https://www.npmjs.com/package/@gcds-core/components-react",
+    "npmGcdsComponentsVue": "https://www.npmjs.com/package/@gcds-core/components-vue",
 
     "tbsStandardsOnWebA11y": "https://www.tbs-sct.canada.ca/pol/doc-eng.aspx?id=23601",
     "wcag": "https://www.w3.org/TR/WCAG21/",

--- a/src/en/start-to-use/angular.md
+++ b/src/en/start-to-use/angular.md
@@ -33,7 +33,7 @@ Follow these steps to install and use GC Design System components in your Angula
 Navigate to your project’s root folder and run the following command:
 
 ```js
-npm install @cdssnc/gcds-components @cdssnc/gcds-components-angular
+npm install @gcds-core/components @gcds-core/components-angular
 ```
 
 ### 2. Import GC Design System
@@ -41,7 +41,7 @@ npm install @cdssnc/gcds-components @cdssnc/gcds-components-angular
 Place the following code in the `app.module.ts` file of your app:
 
 ```js
-import { GcdsComponentsModule } from '@cdssnc/gcds-components-angular';
+import { GcdsComponentsModule } from '@gcds-core/components-angular';
 
 @NgModule({
   declarations: [
@@ -61,7 +61,7 @@ export class AppModule { }
 Place the following code in the `styles.scss` file of your app to import GC Design System styles:
 
 ```js
-@import '../node_modules/@cdssnc/gcds-components/dist/gcds/gcds.css';
+@import '../node_modules/@gcds-core/components/dist/gcds/gcds.css';
 ```
 
 {% addCssShortcuts 'en', '3' %}{% endaddCssShortcuts %}

--- a/src/en/start-to-use/html.md
+++ b/src/en/start-to-use/html.md
@@ -63,7 +63,7 @@ Based on your selection, follow the steps to install GC Design System components
 Navigate to your project’s root folder and run the following command:
 
 ```js
-npm install @cdssnc/gcds-components
+npm install @gcds-core/components
 ```
 
 ### 2. Include GC Design System in your project
@@ -74,11 +74,11 @@ Add the following `link` tags inside the `head` tag of your `HTML` files to load
 <!-- GC Design System -->
 <link
   rel="stylesheet"
-  href="/node_modules/@cdssnc/gcds-components/dist/gcds/gcds.css"
+  href="/node_modules/@gcds-core/components/dist/gcds/gcds.css"
 />
 <script
   type="module"
-  src="/node_modules/@cdssnc/gcds-components/dist/gcds/gcds.esm.js"
+  src="/node_modules/@gcds-core/components/dist/gcds/gcds.esm.js"
 ></script>
 ```
 
@@ -121,11 +121,11 @@ Current version: Version <code><span id='cdn-latest-version'></span></code>, rel
 <!-- GC Design System -->
 <link
   rel="stylesheet"
-  href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@||version||/dist/gcds/gcds.css"
+  href="https://cdn.design-system.alpha.canada.ca/@gcds-core/components@||version||/dist/gcds/gcds.css"
 />
 <script
   type="module"
-  src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@||version||/dist/gcds/gcds.esm.js"
+  src="https://cdn.design-system.alpha.canada.ca/@gcds-core/components@||version||/dist/gcds/gcds.esm.js"
 ></script>
 ```
 

--- a/src/en/start-to-use/react.md
+++ b/src/en/start-to-use/react.md
@@ -34,7 +34,7 @@ Follow these steps to install and use GC Design System components in your React 
 Navigate to your project’s root folder and run the following command:
 
 ```js
-npm install @cdssnc/gcds-components @cdssnc/gcds-components-react
+npm install @gcds-core/components @gcds-core/components-react
 ```
 
 ### 2. Import GC Design System
@@ -42,7 +42,7 @@ npm install @cdssnc/gcds-components @cdssnc/gcds-components-react
 Place the following code in the `index.js` file of your app to import GC Design System styles:
 
 ```js
-import '@cdssnc/gcds-components-react/gcds.css';
+import '@gcds-core/components-react/gcds.css';
 ```
 
 {% addCssShortcuts 'en', '3' %}{% endaddCssShortcuts %}

--- a/src/en/start-to-use/vue.md
+++ b/src/en/start-to-use/vue.md
@@ -34,7 +34,7 @@ Follow these steps to install and use GC Design System components in your Vue pr
 Navigate to your project’s root folder and run the following command:
 
 ```js
-npm install @cdssnc/gcds-components-vue
+npm install @gcds-core/components-vue
 ```
 
 ### 2. Import GC Design System
@@ -42,7 +42,7 @@ npm install @cdssnc/gcds-components-vue
 In your `main.js` file, import the GC Design System components plugin and use it:
 
 ```js
-import { GcdsComponents } from '@cdssnc/gcds-components-vue';
+import { GcdsComponents } from '@gcds-core/components-vue';
 
 createApp(App).use(GcdsComponents).mount('#app');
 ```
@@ -59,14 +59,14 @@ There are 2 ways to do this:
 a. Import the styles to your `main.js` file, alongside your `style.css`:
 
 ```js
-import '@cdssnc/gcds-components-vue/gcds.css';
+import '@gcds-core/components-vue/gcds.css';
 import './style.css';
 ```
 
 b. Import the styles to your `App.vue` using the HTML `style` tag:
 
 ```html
-<style src="@cdssnc/gcds-components-vue/gcds.css">
+<style src="@gcds-core/components-vue/gcds.css">
   /* global styles */
 </style>
 ```

--- a/src/fr/demarrer/angular.md
+++ b/src/fr/demarrer/angular.md
@@ -33,7 +33,7 @@ Suivez ces étapes pour installer et utiliser les composants de Système de desi
 Naviguez vers le dossier racine de votre projet et exécutez la commande suivante :
 
 ```js
-npm install @cdssnc/gcds-components @cdssnc/gcds-components-angular
+npm install @gcds-core/components @gcds-core/components-angular
 ```
 
 ### 2. Importer Système de design GC
@@ -41,7 +41,7 @@ npm install @cdssnc/gcds-components @cdssnc/gcds-components-angular
 Insérez le code suivant dans le fichier `app.module.ts` de votre application :
 
 ```js
-import { GcdsComponentsModule } from '@cdssnc/gcds-components-angular';
+import { GcdsComponentsModule } from '@gcds-core/components-angular';
 
 @NgModule({
   declarations: [
@@ -61,7 +61,7 @@ export class AppModule { }
 Pour importer les styles de Système de design GC, insérez le code suivant dans le fichier `styles.scss` de votre application :
 
 ```js
-@import '../node_modules/@cdssnc/gcds-components/dist/gcds/gcds.css';
+@import '../node_modules/@gcds-core/components/dist/gcds/gcds.css';
 ```
 
 {% addCssShortcuts 'fr', '3' %}{% endaddCssShortcuts %}

--- a/src/fr/demarrer/html.md
+++ b/src/fr/demarrer/html.md
@@ -63,7 +63,7 @@ Sélectionnez parmi les options suivantes, puis suivez les étapes pour installe
 Naviguez vers le dossier racine de votre projet et exécutez la commande suivante :
 
 ```js
-npm install @cdssnc/gcds-components
+npm install @gcds-core/components
 ```
 
 ### 2. Inclure Système de design GC dans votre projet
@@ -74,11 +74,11 @@ Ajoutez les balises `link` suivantes à l’intérieur de la balise `head` de vo
 <!-- Système de design GC -->
 <link
   rel="stylesheet"
-  href="/node_modules/@cdssnc/gcds-components/dist/gcds/gcds.css"
+  href="/node_modules/@gcds-core/components/dist/gcds/gcds.css"
 />
 <script
   type="module"
-  src="/node_modules/@cdssnc/gcds-components/dist/gcds/gcds.esm.js"
+  src="/node_modules/@gcds-core/components/dist/gcds/gcds.esm.js"
 ></script>
 ```
 
@@ -121,11 +121,11 @@ Version actuelle : Version <code><span id='cdn-latest-version'></span></code>, p
 <!-- Système de design GC -->
 <link
   rel="stylesheet"
-  href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@||version||/dist/gcds/gcds.css"
+  href="https://cdn.design-system.alpha.canada.ca/@gcds-core/components@||version||/dist/gcds/gcds.css"
 />
 <script
   type="module"
-  src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@||version||/dist/gcds/gcds.esm.js"
+  src="https://cdn.design-system.alpha.canada.ca/@gcds-core/components@||version||/dist/gcds/gcds.esm.js"
 ></script>
 ```
 

--- a/src/fr/demarrer/react.md
+++ b/src/fr/demarrer/react.md
@@ -34,7 +34,7 @@ Suivez ces étapes pour installer et utiliser les composants de Système de desi
 Naviguez vers le dossier racine de votre projet et exécutez la commande suivante :
 
 ```js
-npm install @cdssnc/gcds-components @cdssnc/gcds-components-react
+npm install @gcds-core/components @gcds-core/components-react
 ```
 
 ### 2. Importer Système de design GC
@@ -42,7 +42,7 @@ npm install @cdssnc/gcds-components @cdssnc/gcds-components-react
 Pour importer les styles de Système de design GC, insérez le code suivant dans le fichier `index.js` de votre application :
 
 ```js
-import '@cdssnc/gcds-components-react/gcds.css';
+import '@gcds-core/components-react/gcds.css';
 ```
 
 {% addCssShortcuts 'fr', '3' %}{% endaddCssShortcuts %}

--- a/src/fr/demarrer/vue.md
+++ b/src/fr/demarrer/vue.md
@@ -34,7 +34,7 @@ Suivez ces étapes pour installer et utiliser les composants de Système de desi
 Naviguez vers le dossier racine de votre projet et exécutez la commande suivante :
 
 ```js
-npm install @cdssnc/gcds-components-vue
+npm install @gcds-core/components-vue
 ```
 
 ### 2. Importer Système de design GC
@@ -42,7 +42,7 @@ npm install @cdssnc/gcds-components-vue
 Dans votre fichier `main.js`, importez le plugiciel des composants de Système de design GC et utilisez-le :
 
 ```js
-import { GcdsComponents } from '@cdssnc/gcds-components-vue';
+import { GcdsComponents } from '@gcds-core/components-vue';
 
 createApp(App).use(GcdsComponents).mount('#app');
 ```
@@ -59,14 +59,14 @@ Il y a 2 façons de le faire :
 a. Importez les styles dans votre fichier `main.js`, à côté de votre `style.css`:
 
 ```js
-import '@cdssnc/gcds-components-vue/gcds.css';
+import '@gcds-core/components-vue/gcds.css';
 import './style.css';
 ```
 
 b. Importez les styles dans fichier `App.vue` en utilisant la balise HTML `style` :
 
 ```html
-<style src="@cdssnc/gcds-components-vue/gcds.css">
+<style src="@gcds-core/components-vue/gcds.css">
   /* global styles */
 </style>
 ```

--- a/src/fr/fr.json
+++ b/src/fr/fr.json
@@ -192,10 +192,10 @@
     "githubTokens": "https://github.com/cds-snc/gcds-tokens",
     "githubTokensIssues": "https://github.com/cds-snc/gcds-tokens/issues",
 
-    "npmGcdsComponents": "https://www.npmjs.com/package/@cdssnc/gcds-components",
-    "npmGcdsComponentsAngular": "https://www.npmjs.com/package/@cdssnc/gcds-components-angular",
-    "npmGcdsComponentsReact": "https://www.npmjs.com/package/@cdssnc/gcds-components-react",
-    "npmGcdsComponentsVue": "https://www.npmjs.com/package/@cdssnc/gcds-components-vue",
+    "npmGcdsComponents": "https://www.npmjs.com/package/@gcds-core/components",
+    "npmGcdsComponentsAngular": "https://www.npmjs.com/package/@gcds-core/components-angular",
+    "npmGcdsComponentsReact": "https://www.npmjs.com/package/@gcds-core/components-react",
+    "npmGcdsComponentsVue": "https://www.npmjs.com/package/@gcds-core/components-vue",
 
     "tbsStandardsOnWebA11y": "https://www.tbs-sct.canada.ca/pol/doc-fra.aspx?id=23601",
 


### PR DESCRIPTION
# Summary | Résumé

With the `v1.0.0` launch coming up, update the installation instructions to reference the newer `@gcds-core` package scope.