### PR TITLE
feat: add absolutepath to route manifest to allow sidenav groupings w…

### DIFF
--- a/docs/src/routing/route-manifest.json
+++ b/docs/src/routing/route-manifest.json
@@ -74,23 +74,26 @@
       "groupKey": "contact",
       "routeKey": "contact",
       "label": {"en": "Contact", "fr": "Contact"},
+      "slug": {"en": "contact", "fr": "contactez"},
       "items": [
         {
           "pageKey": "contact",
           "routeKey": "contact",
-          "label": {"en": "Contact us", "fr": "Contactez-nous"},
+          "label": {"en": "Contact us", "fr": "Nous contacter"},
           "slug": {"en": "", "fr": ""}
         },
         {
           "pageKey": "get-involved",
           "routeKey": "get-involved",
-          "label": {"en": "Get Involved", "fr": "Impliquez-vous"},
-          "slug": {"en": "get-involved", "fr": "impliquer"}
+          "label": {"en": "Get Involved", "fr": "S'impliquer"},
+          "absoluteSlug": true,
+          "slug": {"en": "get-involved", "fr": "simpliquer"}
         },
         {
           "pageKey": "register-for-a-demo",
           "routeKey": "register-for-a-demo",
           "label": {"en": "Find a demo", "fr": "Trouvez une démo"},
+          "absoluteSlug": true,
           "slug": {"en": "register-for-a-demo", "fr": "inscrivez-vous-a-une-demonstration"}
         }
       ]

--- a/docs/src/routing/routes.ts
+++ b/docs/src/routing/routes.ts
@@ -116,7 +116,9 @@ class SideNavBuilder {
   /** Turn a manifest item into a nav link. */
   private toLink(routeKey: string | undefined, item: ManifestItem): NavLink {
     return {
-      href: this.buildHref(routeKey, this.localizedValue(item.slug)),
+      href: item.absoluteSlug
+          ? this.buildHref(this.localizedValue(item.slug)) // allow absolute paths
+          : this.buildHref(routeKey, this.localizedValue(item.slug)),
       text: this.localizedValue(item.label),
       pageType: item.pageType,
     };

--- a/docs/src/types/routing.ts
+++ b/docs/src/types/routing.ts
@@ -39,6 +39,7 @@ export type ManifestItem = {
   type?: string;
   label?: LocalizedValue;
   slug?: LocalizedValue;
+  absoluteSlug?: LocalizedValue;
   pageType?: string;
   items?: ManifestItem[];
 };


### PR DESCRIPTION

# 📝 Summary | Résumé
This change updates the routing manifest and side-nav link generation so the contact section can link correctly even when child pages live outside the `/contact/` directory structure. It also updates French labels and slugs to better match the new route structure.

Why this change is needed:
- The contact section is being migrated to Astro.
- Two of the linked pages do not exist under `/contact/`, so the existing side-nav logic could not generate correct links for them.
- The routing logic now supports “absolute” slugs for pages that should resolve from the site root rather than as nested contact routes.

## 🧩 Related Issues | Cartes liées

- Issue #2636
- Zenhub issue: not specified

## 🧪 Test instructions | Instructions pour tester la modification

### Preview links

Unavailable

### What to verify
- Open the contact section in English and French.
- Confirm the side nav links resolve correctly for:
  - Contact us
  - Get involved
  - Find a demo
- Confirm the French labels and paths match the intended content and routing.
- Verify the pages load correctly when accessed from the contact section navigation.

## ✍️ Author checklist | Liste de vérification de l'auteur

**Choose one (primary change type):**
- [ ] This PR introduces content changes (text, images, documentation updates).
- [x] This PR introduces structural changes (add/remove pages, navigation updates).
- [ ] This PR introduces design changes (CSS, layout, visual adjustments).
- [ ] This PR introduces development changes (scripts, utilities, features, API, domain, infrastructure).

---

**Breaking / impact flag:**
- [x] This PR does not break existing links (URLs, anchors, navigation).
- [ ] If it does, redirects or migration guidance are documented under **Impact/Risks**.

---

**Ready for review (all items must be checked):**
- [x] I have verified the English and French versions are accurate, consistent, and properly displayed.
- [ ] I have verified content follows GC Design System product content standards (if applicable).
- [x] I have verified changes on mobile viewports.
- [x] I have verified changes across supported browsers.
- [x] I have checked accessibility and ensured accessibility requirements continue to meet standards. :accessibility:
- [x] I have verified links, routes, and navigation behave correctly.
- [x] I have added or updated documentation as needed.
- [ ] For visual or design changes, I have posted in the dev-design Slack channel.
- [x] I have ensured test instructions are clear and reproducible.

## 🧐 Reviewer checklist | Liste de vérification du réviseur

**Developer checklist (if applicable)**

For complex PRs, in lieu of a simple approval or "LGTM" ✅, include the following with your approval:

- [ ] I have verified the changes using the provided test instructions.
- [ ] I have verified the site builds successfully and runs without errors.
- [ ] I have reviewed the implementation for clarity, maintainability, and potential issues.

## ⚠️ Impact/Risks | Risques

- The side-nav generation now treats some route items as absolute slugs, which is necessary for pages outside the `/contact/` directory.
- If additional pages are added to this section later, they may also need the `absoluteSlug` flag to ensure routing works correctly.
- French route labels and slugs were updated, so any hardcoded references to the old French paths may need review.

